### PR TITLE
Fix for issue #37 (IE7 issue)

### DIFF
--- a/jquery.popupoverlay.js
+++ b/jquery.popupoverlay.js
@@ -345,7 +345,7 @@
                             parseInt($el.css('margin-top'), 10) +
                             parseInt($el.css('margin-bottom'), 10)
                         )
-                    )/2 +'px',
+                    )/2 +'px'
                 });
             }
 


### PR DESCRIPTION
This commit addresses issue #37. Fixed typo effecting array size. Most browsers will auto correct this, but IE7 will not.
