### PR TITLE
Properly support nested "scrolllock=true" popups

### DIFF
--- a/jquery.popupoverlay.js
+++ b/jquery.popupoverlay.js
@@ -513,9 +513,13 @@
                         }
                     }
 
-                    // Re-enable scrolling of background layer
+                    // Re-enable scrolling of background layer, if needed
                     if (options.scrolllock) {
                         setTimeout(function() {
+                            if ($.grep(visiblePopupsArray, function(eid) { return $("#"+eid).data('popupoptions').scrolllock }).length) {
+                                // Some "scolllock=true" popup is currently visible, leave scrolling disabled
+                                return;
+                            }
                             $body.css({
                                 overflow: 'visible',
                                 'margin-right': bodymarginright
@@ -532,9 +536,13 @@
                     $wrapper.hide();
                 }
 
-                // Re-enable scrolling of background layer
+                // Re-enable scrolling of background layer, if needed
                 if (options.scrolllock) {
                     setTimeout(function() {
+                        if ($.grep(visiblePopupsArray, function(eid) { return $("#"+eid).data('popupoptions').scrolllock }).length) {
+                            // Some "scrolllock=true" popup is currently visible, leave scrolling disabled
+                            return;
+                        }
                         $body.css({
                             overflow: 'visible',
                             'margin-right': bodymarginright


### PR DESCRIPTION
I found out that if a "scrolllock=true" popup is created on top of another "scrolllock=true" popup, then closing the inner popup causes `<body>` scrolling to be restored. This PR corrects this problem.