### PR TITLE
Add the "confirmclose" event

### DIFF
--- a/index.html
+++ b/index.html
@@ -388,6 +388,11 @@
         </tr>
         </thead>
         <tbody>
+        <tr>
+            <td>confirmclose</td>
+            <td>function</td>
+            <td>Callback function which will execute when the popup is requested to close. The popup will only close if it returns true.</td>
+        </tr>
        <tr>
             <td>beforeopen</td>
             <td>function</td>

--- a/jquery.popupoverlay.js
+++ b/jquery.popupoverlay.js
@@ -448,9 +448,19 @@
             var $background = $('#' + el.id + '_background');
 
             // Confirm close
-            if (options.confirmclose && !callback(el, lastclicked[el.id], options.confirmclose)) {
-                // Not confirmed
-                return;
+            if (options.confirmclose) {
+                if (!callback(el, lastclicked[el.id], options.confirmclose)) {
+                    // Not confirmed
+                    return;
+                }
+
+                // During callback execution, visibility of popup(s) could have changed,
+                // so we re-find this popup in visiblePopupsArray.
+                var popupIdIndex = $.inArray(el.id, visiblePopupsArray);
+                if (popupIdIndex === -1) {
+                    // This popup was already hidden, nothing more to do.
+                    return;
+                }
             }
 
             if(opentimer) clearTimeout(opentimer);

--- a/jquery.popupoverlay.js
+++ b/jquery.popupoverlay.js
@@ -441,13 +441,19 @@
                 return;
             }
 
-            if(opentimer) clearTimeout(opentimer);
-
             var $body = $('body');
             var $el = $(el);
             var options = $el.data('popupoptions');
             var $wrapper = $('#' + el.id + '_wrapper');
             var $background = $('#' + el.id + '_background');
+
+            // Confirm close
+            if (options.confirmclose && !callback(el, lastclicked[el.id], options.confirmclose)) {
+                // Not confirmed
+                return;
+            }
+
+            if(opentimer) clearTimeout(opentimer);
 
             $el.data('popup-visible', false);
 
@@ -679,7 +685,7 @@
         openelement =  options.openelement ? options.openelement : ('.' + el.id + opensuffix);
         elementclicked = $(openelement + '[data-popup-ordinal="' + ordinal + '"]');
         if (typeof func == 'function') {
-            func.call($(el), el, elementclicked);
+            return func.call($(el), el, elementclicked);
         }
     };
 
@@ -839,6 +845,7 @@
         closeelement: null,
         transition: null,
         tooltipanchor: null,
+        confirmclose: null,
         beforeopen: null,
         onclose: null,
         onopen: null,


### PR DESCRIPTION
I needed the ability to prevent the popup from being closed under certain conditions, for example, to allow the user to double-check and either confirm or cancel close. (This ability is present in https://github.com/jquerytools/jquerytools which I try to migrate from.) So I added the `confirmclose` event that is called before any changes are made, if the event returns non-true, then close is cancelled.