### PR TITLE
Don't close when the click originated from inside the popup

### DIFF
--- a/jquery.popupoverlay.js
+++ b/jquery.popupoverlay.js
@@ -705,6 +705,12 @@
         }
     });
 
+    var mousedownTarget;
+
+    $(document).on('mousedown', function (event) {
+        mousedownTarget = event.target;
+    });
+
     // Hide popup on click
     $(document).on('click', function (event) {
         if(visiblePopupsArray.length) {
@@ -723,6 +729,7 @@
                 && $(el).data('popupoptions').blur
                 && !$(event.target).closest($(el).data('popupoptions').blurignore).length
                 && !$(event.target).closest('#' + elementId).length
+                && !$(mousedownTarget).closest('#' + elementId).length
                 && event.which !== 2
                 && $(event.target).is(':visible')) {
 


### PR DESCRIPTION
We have some popups that contain text fields, when people select text in those fields by clicking and dragging, they often mouse up outside the popup which closes it.

This change stops the popup being closed in this scenario. It can still be closed by doing a full click (mouse down and up) outside the popup.